### PR TITLE
prctl: introduce PR_GET_NR_THREADS flag

### DIFF
--- a/include/uapi/linux/prctl.h
+++ b/include/uapi/linux/prctl.h
@@ -272,4 +272,7 @@ struct prctl_mm_map {
 # define PR_SCHED_CORE_SCOPE_THREAD_GROUP	1
 # define PR_SCHED_CORE_SCOPE_PROCESS_GROUP	2
 
+/* Retrieve total number of threads in the process */
+#define PR_GET_NR_THREADS		63
+
 #endif /* _LINUX_PRCTL_H */

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -2230,6 +2230,17 @@ static int prctl_get_tid_address(struct task_struct *me, int __user * __user *ti
 }
 #endif
 
+static int prctl_get_nr_threads(struct task_struct *me, unsigned int __user *dest)
+{
+	unsigned int threads_count;
+
+	int nr_threads = get_nr_threads(me);
+	WARN_ON(nr_threads < 1);
+	threads_count = max(1, nr_threads);
+
+	return put_user(threads_count, dest);
+}
+
 static int propagate_has_child_subreaper(struct task_struct *p, void *data)
 {
 	/*
@@ -2530,6 +2541,9 @@ SYSCALL_DEFINE5(prctl, int, option, unsigned long, arg2, unsigned long, arg3,
 		error = sched_core_share_pid(arg2, arg3, arg4, arg5);
 		break;
 #endif
+	case PR_GET_NR_THREADS:
+		error = prctl_get_nr_threads(me, (unsigned int __user *)arg2);
+		break;
 	default:
 		error = -EINVAL;
 		break;

--- a/tools/include/uapi/linux/prctl.h
+++ b/tools/include/uapi/linux/prctl.h
@@ -272,4 +272,7 @@ struct prctl_mm_map {
 # define PR_SCHED_CORE_SCOPE_THREAD_GROUP	1
 # define PR_SCHED_CORE_SCOPE_PROCESS_GROUP	2
 
+/* Retrieve total number of threads in the process */
+#define PR_GET_NR_THREADS		63
+
 #endif /* _LINUX_PRCTL_H */

--- a/tools/testing/selftests/prctl/.gitignore
+++ b/tools/testing/selftests/prctl/.gitignore
@@ -2,3 +2,4 @@
 disable-tsc-ctxt-sw-stress-test
 disable-tsc-on-off-stress-test
 disable-tsc-test
+get-nr-threads-test

--- a/tools/testing/selftests/prctl/Makefile
+++ b/tools/testing/selftests/prctl/Makefile
@@ -2,15 +2,20 @@
 ifndef CROSS_COMPILE
 uname_M := $(shell uname -m 2>/dev/null || echo not)
 ARCH ?= $(shell echo $(uname_M) | sed -e s/i.86/x86/ -e s/x86_64/x86/)
+CFLAGS += -pthread
+
+TEST_PROGS := get-nr-threads-test
 
 ifeq ($(ARCH),x86)
-TEST_PROGS := disable-tsc-ctxt-sw-stress-test disable-tsc-on-off-stress-test \
+TEST_PROGS += disable-tsc-ctxt-sw-stress-test \
+		disable-tsc-on-off-stress-test \
 		disable-tsc-test
+endif
+
 all: $(TEST_PROGS)
 
 include ../lib.mk
 
 clean:
 	rm -fr $(TEST_PROGS)
-endif
 endif

--- a/tools/testing/selftests/prctl/get-nr-threads-test.c
+++ b/tools/testing/selftests/prctl/get-nr-threads-test.c
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Test for prctl(PR_GET_NR_THREADS, ...)
+ *
+ * Basic test to check the behaviour of PR_GET_NR_THREADS
+ */
+
+#include <assert.h>
+//#include <inttypes.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <sys/prctl.h>
+#include <linux/prctl.h>
+
+#ifndef PR_GET_NR_THREADS
+#define PR_GET_NR_THREADS 63
+#endif
+
+void assert_nr_threads(unsigned int expected)
+{
+	unsigned int num_threads = 0;
+
+	printf("prctl(PR_GET_NR_THREADS, ...)\n");
+	if (prctl(PR_GET_NR_THREADS, &num_threads) == -1) {
+		perror("prctl");
+		fflush(stdout);
+		exit(EXIT_FAILURE);
+	}
+	printf("num_threads == %d\n", num_threads);
+	assert(num_threads == expected);
+	return;
+}
+
+void *threaded_assert(void *input)
+{
+	assert_nr_threads(2);
+	return NULL;
+}
+
+int main(void)
+{
+	int r;
+	pthread_t tinfo;
+
+	assert_nr_threads(1);
+
+	r = pthread_create(&tinfo, NULL, threaded_assert, NULL);
+	assert(r == 0);
+
+	r = pthread_join(tinfo, NULL);
+	assert_nr_threads(1);
+
+	fflush(stdout);
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds a new PR_GET_NR_THREADS flag to prctl(2), which directly
exposes to userspace the thread-count from signal_struct.

It allows a calling process to self-introspect its own state and
detect whether it is currently executing in a single or
multi-threaded way.

This additional primitive is relevant for all those kinds of logic
which may not be safe or sound to execute in a multi-threaded
process (e.g. POSIX MT-Unsafe, setns(2) limitations, and more).

In particular, it caters to libraries which need to perform
such introspection in an efficient way and without having to resort
to procfs access (which may not be available, and additionally
requires FD-opening plus counting/parsing steps).

Signed-off-by: Luca BRUNO <lucab@lucabruno.net>